### PR TITLE
Set the default-directory of comint buffers

### DIFF
--- a/inf-elixir.el
+++ b/inf-elixir.el
@@ -141,7 +141,8 @@ Always returns a REPL buffer for DIR."
     (if (process-live-p (inf-elixir--get-project-process dir))
         (inf-elixir--get-project-buffer dir)
       (with-current-buffer
-          (apply #'make-comint-in-buffer buf-name nil (car cmd) nil (cdr cmd))
+          (let ((default-directory (or dir default-directory)))
+            (apply #'make-comint-in-buffer buf-name nil (car cmd) nil (cdr cmd)))
         (inf-elixir-mode)
         (when dir (inf-elixir--set-project-buffer dir (current-buffer)))
         (current-buffer)))))


### PR DESCRIPTION
I use Nix, [nix-direnv](https://github.com/nix-community/nix-direnv), and `direnv-mode` to configure project-specific dependencies. I am currently working on my project that depends on a library that contains Rust NIF, so I have configured Nix and direnv to ensure `cargo` is available in my project.

When I tried to open a REPL session for the project using `inf-elixir-project`, it failed due to `cargo` missing. On the other hand, `mix compile` successfully runs on terminal.

Apparently, iex does not load the local environment from direnv when inf-elixir starts the session. I think this can be done by setting `default-directory` of the comint buffer, which is implemented in this PR. It seems to be working in my environment, and `inf-elixir` now handles the cargo dependency!

Hope this is useful.