### PR TITLE
Add support for IEx's open command

### DIFF
--- a/inf-elixir.el
+++ b/inf-elixir.el
@@ -59,6 +59,16 @@ Should be able to be run without any arguments."
   :type 'string
   :group 'inf-elixir)
 
+(defcustom inf-elixir-open-command "emacsclient --no-wait +__LINE__ __FILE__"
+  "Value to be populated into the `ELIXIR_EDITOR' environment variable.
+
+The `ELIXIR_EDITOR' is used by the IEx `open/1' helper to open files from the
+REPL.  Run `h(open)' in an IEx shell for more information about `ELIXIR_EDITOR'.
+
+NOTE: Changing this variable will not affect running REPLs."
+  :type 'string
+  :group 'inf-elixir)
+
 
 ;;; Mode definitions and configuration
 (defvar inf-elixir-project-buffers (make-hash-table :test 'equal)
@@ -140,6 +150,7 @@ Always returns a REPL buffer for DIR."
   (let ((buf-name (inf-elixir--buffer-name dir)))
     (if (process-live-p (inf-elixir--get-project-process dir))
         (inf-elixir--get-project-buffer dir)
+      (setenv "ELIXIR_EDITOR" inf-elixir-open-command)
       (with-current-buffer
           (apply #'make-comint-in-buffer buf-name nil (car cmd) nil (cdr cmd))
         (inf-elixir-mode)


### PR DESCRIPTION
Allow an inf-elixir buffer to use [IEx's `open` command](https://hexdocs.pm/iex/IEx.Helpers.html#open/1), opening the term given in an Emacs buffer. This is currently done by setting the `ELIXIR_EDITOR` in the inf-elixir buffer, defaulting to `emacsclient --no-wait +__LINE__ __FILE__`.

### The Downside

The problem with this approach is, essentially, `emacsclient`. In order for this to work correctly, the user must have `emacsclient` in their `$PATH`. Also, the fact that this functionality relies on an external program makes it rather hard to test. I really wanted a solution that used something like `find-file` under-the-hood, but I can't seem to find any way to do that.

### In Conclusion

I'm going to leave this PR up for a couple of days to see if anyone has any ideas on how this could be more elegantly implemented.