### PR TITLE
Replace obsoleted functions

### DIFF
--- a/inf-elixir.el
+++ b/inf-elixir.el
@@ -306,7 +306,7 @@ be prompted for the REPL command.  The default is provided by
 (defun inf-elixir-send-line ()
   "Send the region to the REPL buffer and run it."
   (interactive)
-  (inf-elixir--send (buffer-substring (point-at-bol) (point-at-eol))))
+  (inf-elixir--send (buffer-substring (line-beginning-position) (line-end-position))))
 
 (defun inf-elixir-send-region ()
   "Send the region to the REPL buffer and run it."


### PR DESCRIPTION
point-at-bol and point-at-eol will be obsoleted since Emacs 29.1. This PR fixes the following warnings.

```
In inf-elixir-send-line:
inf-elixir.el:309:40: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
inf-elixir.el:309:55: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
```